### PR TITLE
Feature: Asset Groups

### DIFF
--- a/Artemis.Engine/Artemis.Engine.csproj
+++ b/Artemis.Engine/Artemis.Engine.csproj
@@ -64,6 +64,8 @@
     <Compile Include="RenderPipeline.cs" />
     <Compile Include="RenderPipelineException.cs" />
     <Compile Include="Resolution.cs" />
+    <Compile Include="AssetGroup.cs" />
+    <Compile Include="Utilities\DirectoryUtils.cs" />
     <Compile Include="Utilities\Reflection.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Artemis.Engine/AssetGroup.cs
+++ b/Artemis.Engine/AssetGroup.cs
@@ -1,0 +1,112 @@
+﻿using Artemis.Engine.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+
+namespace Artemis.Engine
+{
+    public class AssetGroup
+    {
+
+        /// <summary>
+        /// The unqualified name of this asset group.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// The full name of this asset group all the way up the asset group tree.
+        /// </summary>
+        public string FullName
+        {
+            get
+            {
+                return Parent == null ? Name : Parent.FullName + "." + Name;
+            }
+        }
+
+        /// <summary>
+        /// The parent of this asset group (if it exists).
+        /// </summary>
+        public AssetGroup Parent { get; private set; }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                return (Assets.Count == 0 && Subgroups.Count == 0);
+            }
+        }
+
+        /// <summary>
+        /// The dictionary of subgroups of this group, mapping from unqualified 
+        /// names to associated subgroups.
+        /// </summary>
+        private Dictionary<string, AssetGroup> Subgroups = new Dictionary<string, AssetGroup>();
+
+        /// <summary>
+        /// The dictionary of all assets in this group.
+        /// </summary>
+        private Dictionary<string, object> Assets = new Dictionary<string, object>();
+
+        internal AssetGroup(
+            string pathName, SearchOption option, 
+            string fileSearchQuery = "*", string folderSearchQuery = "*")
+        {
+            Name = Path.GetFileName(pathName);
+
+            // Search for directories to turn into subgroups.
+            if (option == SearchOption.AllDirectories)
+            {
+                var directories = Directory.EnumerateDirectories(
+                    pathName, folderSearchQuery, SearchOption.TopDirectoryOnly);
+
+                foreach (var folderName in directories)
+                {
+                    var subgroup = new AssetGroup(folderName, option, fileSearchQuery, folderSearchQuery);
+
+                    if (subgroup.IsEmpty)
+                    {
+                        continue;
+                    }
+
+                    subgroup.Parent = this;
+                    Subgroups.Add(subgroup.Name, subgroup);
+                }
+            }
+            // Otherwise, option == SearchOption.TopDirectoryOnly, and we only have to look for
+            // asset files in the given directory rather than subdirectories as well.
+
+            var files = Directory.EnumerateFiles(
+                pathName, fileSearchQuery, SearchOption.TopDirectoryOnly);
+
+            foreach (var fileName in files)
+            {
+                var assetFileName = DirectoryUtils.MakeRelativePath(
+                    AssetLoader.ContentFolderName, fileName);
+                var assetName = Path.GetFileName(assetFileName);
+
+                Assets.Add(assetName, AssetLoader.LoadAssetUsingExtension(assetName));
+            }
+
+            // Prune empty subgroups.
+
+            var toRemove = new List<string>();
+
+            foreach (var kvp in Subgroups)
+            {
+                if (kvp.Value.IsEmpty)
+                {
+                    toRemove.Add(kvp.Key);
+                }
+            }
+
+            foreach (var name in toRemove)
+            {
+                Subgroups.Remove(name);
+            }
+
+        }
+    }
+}

--- a/Artemis.Engine/AssetLoader.cs
+++ b/Artemis.Engine/AssetLoader.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace Artemis.Engine
 {
@@ -14,9 +16,23 @@ namespace Artemis.Engine
     {
 
         /// <summary>
+        /// The separator token for an Asset URI. An Asset URI is a string
+        /// that indicates the location in an AssetGroup that an asset is
+        /// found at. For example, "Shared.Images.WallTexture1" is the asset
+        /// with name "WallTexture1" in the subgroup "Shared.Images" of the
+        /// group "Shared".
+        /// </summary>
+        internal const char ASSET_URI_SEPARATOR = '.';
+
+        /// <summary>
         /// The global ContentManager.
         /// </summary>
     	private static ContentManager Content;
+
+        /// <summary>
+        /// The internal dictionary of all asset groups currently loaded in memory.
+        /// </summary>
+        private static Dictionary<string, AssetGroup> LoadedAssetGroups = new Dictionary<string, AssetGroup>();
 
         /// <summary>
         /// Initialize the AssetLoader by supplying the ContentManager.
@@ -46,18 +62,40 @@ namespace Artemis.Engine
         /// <summary>
         /// Load a Texture2D with the given path.
         /// </summary>
-    	public static Texture2D Texture(string name)
+    	public static Texture2D Texture(string name, bool treatAsAssetURI = true)
     	{
+            if (name.Contains(ASSET_URI_SEPARATOR) && treatAsAssetURI)
+            {
+                return AssetFromURI<Texture2D>(name);
+            }
     		return Content.Load<Texture2D>(name);
     	}
 
         /// <summary>
         /// Load a SpriteFont with the given path.
         /// </summary>
-    	public static SpriteFont Font(string name)
+    	public static SpriteFont Font(string name, bool treatAsAssetURI = true)
     	{
+            if (name.Contains(ASSET_URI_SEPARATOR) && treatAsAssetURI)
+            {
+                return AssetFromURI<SpriteFont>(name);
+            }
     		return Content.Load<SpriteFont>(name);
     	}
+
+        /// <summary>
+        /// Get an asset from an Asset URI.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        private static T AssetFromURI<T>(string name)
+        {
+            var firstSeparatorPos = name.IndexOf('.');
+            var rootGroupName = name.Substring(0, firstSeparatorPos);
+            var remainingName = name.Substring(firstSeparatorPos + 1);
+            return LoadedAssetGroups[rootGroupName].GetAsset<T>(remainingName);
+        }
 
         /// <summary>
         /// Tries to determine the type of file to be loaded based on the extension
@@ -86,9 +124,55 @@ namespace Artemis.Engine
                     return Font(nameWithoutExtension);
                 default:
                     throw new ArgumentException(
-                        String.Format("Do not know how to load asset with extension '{0}'.", extension)
+                        String.Format("Unknown asset extension '{0}'.", extension)
                         );
             }
+        }
+
+        /// <summary>
+        /// Load an entire asset group.
+        /// </summary>
+        public static void PrepareAssetGroup( string name
+                                            , SearchOption searchOption
+                                            , string fileSearchQuery    = "*"
+                                            , string folderSearchQuery  = "*"
+                                            , bool pruneEmptyGroups     = true )
+        {
+            LoadedAssetGroups.Add(
+                name, new AssetGroup(
+                    Path.Combine(ContentFolderName, name), searchOption, 
+                    fileSearchQuery, folderSearchQuery, pruneEmptyGroups)
+                    );
+        }
+
+        /// <summary>
+        /// Return a group with the given full name.
+        /// </summary>
+        /// <param name="fullName"></param>
+        /// <returns></returns>
+        public static AssetGroup GetGroup(string fullName)
+        {
+            var parts = fullName.Split(ASSET_URI_SEPARATOR);
+
+            if (parts.Length == 1)
+            {
+                return LoadedAssetGroups[parts[0]];
+            }
+            else
+            {
+                return LoadedAssetGroups[parts[0]].GetSubgroup(parts.Skip(1).ToArray());
+            }
+        }
+
+        /// <summary>
+        /// Unload the asset group with the given name.
+        /// </summary>
+        /// <param name="name"></param>
+        public static void UnloadAssetGroup(string name)
+        {
+            // LoadedAssetGroups[name].Dispose(true);
+
+            LoadedAssetGroups.Remove(name);
         }
     }
 }

--- a/Artemis.Engine/AssetLoader.cs
+++ b/Artemis.Engine/AssetLoader.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Diagnostics;
+using System.IO;
 
 namespace Artemis.Engine
 {
@@ -25,6 +28,22 @@ namespace Artemis.Engine
     	}
 
         /// <summary>
+        /// The full name of the content folder.
+        /// </summary>
+        public static string ContentFolderName
+        {
+            get
+            {
+                // Check this to make sure it's not stupid. (i.e. make sure it doesn't cause
+                // any strange errors in different contexts)
+
+                return Path.Combine(
+                    Directory.GetCurrentDirectory(),
+                    Content.RootDirectory);
+            }
+        }
+
+        /// <summary>
         /// Load a Texture2D with the given path.
         /// </summary>
     	public static Texture2D Texture(string name)
@@ -40,5 +59,36 @@ namespace Artemis.Engine
     		return Content.Load<SpriteFont>(name);
     	}
 
+        /// <summary>
+        /// Tries to determine the type of file to be loaded based on the extension
+        /// type of the file and loads it as said asset.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static object LoadAssetUsingExtension(string name)
+        {
+            var extension = Path.GetExtension(name);
+            if (string.IsNullOrEmpty(extension))
+            {
+                throw new ArgumentException(
+                    String.Format("Cannot load asset '{0}'.", name)
+                    );
+            }
+            var nameWithoutExtension = Path.GetFileNameWithoutExtension(name);
+
+            switch (extension)
+            {
+                case ".png":
+                case ".jpg":
+                case ".jpeg":
+                    return Texture(nameWithoutExtension);
+                case ".spritefont":
+                    return Font(nameWithoutExtension);
+                default:
+                    throw new ArgumentException(
+                        String.Format("Do not know how to load asset with extension '{0}'.", extension)
+                        );
+            }
+        }
     }
 }

--- a/Artemis.Engine/Utilities/DirectoryUtils.cs
+++ b/Artemis.Engine/Utilities/DirectoryUtils.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+
+namespace Artemis.Engine.Utilities
+{
+    public static class DirectoryUtils
+    {
+
+        #region Code by Stackoverflow Users "Dave" and "Marc Gravell"
+        // References: http://stackoverflow.com/a/340454
+        //             http://stackoverflow.com/a/703292
+    
+        /// <summary>
+        /// Creates a relative path from one file or folder to another.
+        /// </summary>
+        public static String MakeRelativePath(String rootDirectory, String childDirectory)
+        {
+            if (String.IsNullOrEmpty(rootDirectory))
+            {
+                throw new ArgumentNullException("rootDirectory");
+            }
+
+            if (String.IsNullOrEmpty(childDirectory))
+            {
+                throw new ArgumentNullException("childDirectory");
+            }
+
+            Uri rootUri = new Uri(rootDirectory);
+
+            // Folders must end in a slash
+            if (!childDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                childDirectory += Path.DirectorySeparatorChar;
+            }
+            Uri childUri = new Uri(childDirectory);
+
+            return Uri.UnescapeDataString(
+                childUri.MakeRelativeUri(rootUri)
+                        .ToString()
+                        .Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        #endregion
+
+    }
+}


### PR DESCRIPTION
I had an idea that might make it easier for users to organize and load/unload their assets in bulk: **Asset Groups**. Asset Groups are just objects that represent directories in the content folder; they have names (the folder name), contain subgroups (sub-folders) and assets (files in the folder). For example, the following content file structure

```
    Shared\
        Images\
            WallTexture1.png
            WallTexture2.png
        Fonts\
            GUIFont1.spritefont
        SomePic.png
```

would be represented by the following Asset Group tree:

```
    AssetGroup("Shared",
        AssetGroup("Images",
            Texture2D("WallTexture1"),
            Texture2D("WallTexture2")
        ),
        AssetGroup("Fonts",
            SpriteFont("GUIFont1")
        ),
        Texture2D("SomePic")
    )
````

(Obviously, that's not how `Texture2D`s and `SpriteFont`s are constructed, but this is just to demonstrate the "idea" of an asset group).

The user would never directly create an asset group, they would only ever call `AssetLoader.PrepareAssetGroup("path")`, where `"path"` is relative to the root content folder. So the above asset group could be created by calling `AssetLoader.PrepareAssetGroup("Shared")`, and if the user only wanted to create an asset group for "Images", they would call `AssetLoader.PrepareAssetGroup("Shared\Images")`.

Calling `AssetLoader.PrepareAssetGroup(path)` doesn't actually return the asset group, all it does is it loads the asset group in the asset loader's memory. Then the user can access assets in the group later on using methods in `AssetLoader`.

Now, we don't want users to have to always refer to their assets using a relative path, because paths aren't operating system independent (the path "C:\Windows\Things" wouldn't work on an operating system where the "\" is replaced by "/" or ":"), so when they want to access an asset that's been loaded into some asset group tree, then they use an **asset URI** (Uniform Resource Indicator).

An asset URI is just platform-independent name for referring to the location of an asset in an asset group tree. For any asset with some path, it's asset URI is just its path with all the path separator characters replaced by ".". For example, "Shared\Images\WallTexture1" becomes "Shared.Images.WallTexture1".

What's useful about this notation is that it is platform-independent, it encourages organization of asset folders into parts that have logical asset URIs, and it not only works with individual assets but it also works with groups. For example, if the user wanted to get the entire group "Images" in the above example, they could call `AssetLoader.GetGroup("Shared.Images")`.

What do you think? Is this a useful feature to add? Are there improvements that should be made? Share your thoughts.