### PR TITLE
Added ForceUpdateAttribute and optimized ArtemisObject.

### DIFF
--- a/Artemis.Engine/ArtemisObject.cs
+++ b/Artemis.Engine/ArtemisObject.cs
@@ -3,6 +3,7 @@
 using Artemis.Engine.Utilities;
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -10,8 +11,62 @@ using System.Reflection;
 
 namespace Artemis.Engine
 {
+
+    /// <summary>
+    /// An ArtemisObject is the most generic form of "game object" found in the ArtemisEngine.
+    /// </summary>
     public class ArtemisObject
     {
+
+        // The following dictionary maps from an Attribute Type object to a dictionary of known
+        // subclasses of ArtemisObject. The nested dictionary maps from the sub Type of ArtemisObject
+        // to a bool determining whether or not the subtype has said attribute applied to it.
+        //
+        // This speeds up the lookup in ArtemisObject's constructor so that creating a bunch of
+        // instances of a subclass of ArtemisObject doesn't result in tons of calls to HasAttribute,
+        // which is worlds slower than a Dictionary lookup.
+
+        private static Dictionary<Type, Dictionary<Type, bool>> knownSubclassAttributes
+            = new Dictionary<Type, Dictionary<Type, bool>>();
+
+        static ArtemisObject()
+        {
+            knownSubclassAttributes.Add(typeof(HasDynamicPropertiesAttribute), new Dictionary<Type, bool>());
+            knownSubclassAttributes.Add(typeof(ForceUpdateAttribute), new Dictionary<Type, bool>());
+        }
+
+        /// <summary>
+        /// Checks if the given type is contained in the given dictionary of known
+        /// types with the given attribute, and if it is performs the given action,
+        /// otherwise checks if it possesses the given attribute. If it does, it's
+        /// added to the dictionary with value "true" and the action is performed,
+        /// otherwise it's added to the dictionary with value "false".
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="attr"></param>
+        /// <param name="hasAttrDict"></param>
+        /// <param name="action"></param>
+        private static void CheckForAttributeAndPerformAction(Type type, Type attr, Action action)
+        {
+            var knownSubclasses = knownSubclassAttributes[attr];
+            if (!knownSubclasses.ContainsKey(type))
+            {
+                if (Reflection.HasAttribute(type, attr))
+                {
+                    action();
+                    knownSubclasses.Add(type, true);
+                }
+                else
+                {
+                    knownSubclasses.Add(type, false);
+                }
+            }
+            else if (knownSubclasses[type])
+            {
+                action();
+            }
+        }
+
         /// <summary>
         /// The list of attributes attached to the object
         /// </summary>
@@ -26,7 +81,6 @@ namespace Artemis.Engine
 
         protected ArtemisObject()
         {
-
             Fields = new DynamicFieldContainer();
 
             var thisType = this.GetType();
@@ -34,21 +88,33 @@ namespace Artemis.Engine
             // If this object is marked with a HasDynamicPropertiesAttribute then
             // we have to add all the properties marked with DynamicPropertyAttribute
             // to the DynamicFieldContainer.
-            if (Reflection.HasAttribute<HasDynamicPropertiesAttribute>(thisType))
-            {
-                var attribute = (HasDynamicPropertiesAttribute)Attribute.GetCustomAttribute(
+            CheckForAttributeAndPerformAction(
+                thisType, typeof(HasDynamicPropertiesAttribute),  
+                () => SetupDynamicProperties(thisType));
+
+            CheckForAttributeAndPerformAction(
+                thisType, typeof(ForceUpdateAttribute),
+                () => ArtemisEngine.GameUpdater.Add(this));
+        }
+
+        /// <summary>
+        /// Setup the object if it has a HasDynamicProperties attribute.
+        /// </summary>
+        /// <param name="thisType"></param>
+        private void SetupDynamicProperties(Type thisType)
+        {
+            var attribute = (HasDynamicPropertiesAttribute)Attribute.GetCustomAttribute(
                     thisType, typeof(HasDynamicPropertiesAttribute));
 
-                if (attribute.HasDynamicPropertyList)
-                {
-                    var properties = from name in attribute.DynamicPropertyNames
-                                     select thisType.GetProperty(name);
-                    AddDynamicProperties(properties.ToArray());
-                }
-                else
-                {
-                    AddDynamicProperties(thisType.GetProperties());
-                }
+            if (attribute.HasDynamicPropertyList)
+            {
+                var properties = from name in attribute.DynamicPropertyNames
+                                 select thisType.GetProperty(name);
+                AddDynamicProperties(properties.ToArray());
+            }
+            else
+            {
+                AddDynamicProperties(thisType.GetProperties());
             }
         }
 

--- a/Artemis.Engine/ForceUpdateAttribute.cs
+++ b/Artemis.Engine/ForceUpdateAttribute.cs
@@ -1,0 +1,15 @@
+﻿#region Using Statements
+
+using System;
+
+#endregion
+
+namespace Artemis.Engine
+{
+    /// <summary>
+    /// An attribute indicating that an ArtemisObject should be force-updated every
+    /// frame by the GlobalUpdater.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class ForceUpdateAttribute : Attribute { }
+}


### PR DESCRIPTION
The optimization to ArtemisObject is that it's constructor now doesn't call `Reflection.HasAttribute` every time it wants to check if the instance has an attribute, it simply looks up the class in a Dictionary to see if said class has the desired attribute, since `HasAttribtue` is slow af.