### PR TITLE
Fix V3013

### DIFF
--- a/Artemis.Engine/Maths/SpecialFunctions.cs
+++ b/Artemis.Engine/Maths/SpecialFunctions.cs
@@ -1777,7 +1777,7 @@ namespace Artemis.Engine.Maths
         /// <returns></returns>
         public static double CosSqrd(double x)
         {
-            return Math.Pow(Math.Sin(x), 2.0);
+            return Math.Pow(Math.Cos(x), 2.0);
         }
 
         /// <summary>


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bugs, found using PVS-Studio:

- V3013 It is odd that the body of 'SineSqrd' function is fully equivalent to the body of 'CosSqrd' function (1768, line 1778). Artemis.Engine SpecialFunctions.cs 1768

