### PR TITLE
Fix V3127

### DIFF
--- a/Farseer Physics Engine 3.5/Common/PolygonManipulation/SimplifyTools.cs
+++ b/Farseer Physics Engine 3.5/Common/PolygonManipulation/SimplifyTools.cs
@@ -130,7 +130,7 @@ namespace FarseerPhysics.Common.PolygonManipulation
 
                 float dx0 = vertices[middle].X - vertices[lower].X;
                 float dy0 = vertices[middle].Y - vertices[lower].Y;
-                float dx1 = vertices[upper].Y - vertices[middle].X;
+                float dx1 = vertices[upper].X - vertices[middle].X;
                 float dy1 = vertices[upper].Y - vertices[middle].Y;
                 float norm0 = (float)Math.Sqrt(dx0 * dx0 + dy0 * dy0);
                 float norm1 = (float)Math.Sqrt(dx1 * dx1 + dy1 * dy1);


### PR DESCRIPTION
Hello again from  Pinguem.ru competition on finding errors in open source projects. I found another bug  using PVS-Studio:

- V3127 Two similar code fragments were found. Perhaps, this is a typo and 'X' variable should be used instead of 'Y' SimplifyTools.cs 133